### PR TITLE
chore: bump to 0.1.0-beta.10 — add integrations guards, middleware en…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,14 +278,18 @@ The project uses a development workflow without compilation:
 
 The framework package depends on the renderer via `workspace:*`. Yarn Berry resolves this to the actual version at publish time. Raw `npm publish` does not understand `workspace:` and will publish it verbatim, breaking installs for consumers.
 
-Publish order matters — renderer first, then framework:
+Publish order matters — renderer first, then framework. **Always clean and rebuild before publishing** to avoid stale tsup output:
 ```bash
 cd packages/@storybook-astro/renderer
+rm -rf dist && yarn build
 yarn npm publish --tag beta --access public
 
 cd ../framework
+rm -rf dist && yarn build
 yarn npm publish --tag beta --access public
 ```
+
+> **Stale build warning**: The `prepublishOnly` hook runs `tsup`, but tsup may reuse cached output that omits recent source changes. Always `rm -rf dist` before building. After building, verify your changes are in the dist (e.g. `grep` for a known string in `dist/chunk-*.js`) before publishing.
 
 After publishing, promote to `latest` dist-tag so `npm install @storybook-astro/framework` gets the new version:
 ```bash

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -45,13 +45,17 @@ Changes to anything under `packages/@storybook-astro/*` follow the full Gitflow 
 3. Update `CHANGELOG.md`
 4. Final testing (`yarn test`, `yarn lint`)
 5. Merge to `main` and tag (e.g. `v0.1.0-beta.2`)
-6. Publish to npm (renderer first, then framework):
+6. Clean-build and publish to npm (renderer first, then framework):
    ```bash
    cd packages/@storybook-astro/renderer
+   rm -rf dist && yarn build
    yarn npm publish --tag beta --access public
+
    cd ../framework
+   rm -rf dist && yarn build
    yarn npm publish --tag beta --access public
    ```
+   > **Warning — stale builds**: The `prepublishOnly` hook runs `tsup`, but tsup may produce a cached/stale build that omits recent source changes. Always `rm -rf dist` and rebuild explicitly before publishing. Verify the dist output contains your changes (e.g. `grep` for a known string) before running `yarn npm publish`.
 7. Promote to `latest` dist-tag:
    ```bash
    npm dist-tag add @storybook-astro/renderer@x.y.z-beta.N latest

--- a/packages/@storybook-astro/framework/package.json
+++ b/packages/@storybook-astro/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook-astro/framework",
-  "version": "0.1.0-beta.7",
+"version": "0.1.0-beta.10",
   "description": "Community-supported Storybook framework for Astro 6 components",
   "type": "module",
   "license": "MIT",

--- a/packages/@storybook-astro/framework/src/middleware.ts
+++ b/packages/@storybook-astro/framework/src/middleware.ts
@@ -9,6 +9,7 @@ export type HandlerProps = {
 };
 
 export async function handlerFactory(integrations: Integration[]) {
+  const safeIntegrations = integrations ?? [];
   const container = await AstroContainer.create({
     // Somewhat hacky way to force client-side Storybook's Vite to resolve modules properly
     resolve: async (s) => {
@@ -16,7 +17,7 @@ export async function handlerFactory(integrations: Integration[]) {
         return `/@id/${s}`;
       }
 
-      for (const integration of integrations) {
+      for (const integration of safeIntegrations) {
         const resolution = integration.resolveClient(s);
 
         if (resolution) {

--- a/packages/@storybook-astro/framework/src/viteAstroContainerRenderersPlugin.ts
+++ b/packages/@storybook-astro/framework/src/viteAstroContainerRenderersPlugin.ts
@@ -1,6 +1,7 @@
 import type { Integration } from './integrations/index.ts';
 
 export function viteAstroContainerRenderersPlugin(integrations: Integration[]) {
+  const safeIntegrations = integrations ?? [];
   const name = 'astro-container-renderers';
   const virtualModuleId = `virtual:${name}`;
   const resolvedVirtualModuleId = `\0${virtualModuleId}`;
@@ -16,12 +17,12 @@ export function viteAstroContainerRenderersPlugin(integrations: Integration[]) {
 
     load(id: string) {
       if (id === resolvedVirtualModuleId) {
-        const importStatements = buildImportStatements(integrations);
+        const importStatements = buildImportStatements(safeIntegrations);
 
         const code = `
           ${importStatements}
           export function addRenderers(container) {
-            ${integrations.map((integration) => buildServerRenderer(integration) + '\n' + buildClientRenderer(integration)).join('\n')}
+            ${safeIntegrations.map((integration) => buildServerRenderer(integration) + '\n' + buildClientRenderer(integration)).join('\n')}
           }
         `;
 

--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildPrerender.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildPrerender.ts
@@ -26,6 +26,7 @@ import { createViteServer } from './viteStorybookAstroMiddlewarePlugin.ts';
  * - Stories that override the meta component are skipped
  */
 export function vitePluginAstroBuildPrerender(integrations: Integration[]): Plugin {
+  const safeIntegrations = integrations ?? [];
   let viteServer: ViteDevServer | null = null;
   let handler: ((data: HandlerProps) => Promise<string>) | null = null;
 
@@ -41,14 +42,14 @@ export function vitePluginAstroBuildPrerender(integrations: Integration[]): Plug
 
     async buildStart() {
       try {
-        viteServer = await createViteServer(integrations);
+        viteServer = await createViteServer(safeIntegrations);
 
         const filePath = fileURLToPath(new URL('./middleware', import.meta.url));
         const middleware = await viteServer.ssrLoadModule(filePath, {
           fixStacktrace: true
         });
 
-        handler = await middleware.handlerFactory(integrations);
+        handler = await middleware.handlerFactory(safeIntegrations);
       } catch (err) {
         console.warn(
           '[storybook-astro] Failed to create pre-render server:',

--- a/packages/@storybook-astro/framework/src/viteStorybookRendererFallbackPlugin.ts
+++ b/packages/@storybook-astro/framework/src/viteStorybookRendererFallbackPlugin.ts
@@ -1,6 +1,7 @@
 import type { Integration } from './integrations/index.ts';
 
 export function viteStorybookRendererFallbackPlugin(integrations: Integration[]) {
+  const safeIntegrations = integrations ?? [];
   const name = 'storybook-renderer-fallback';
   const virtualModuleId = `virtual:${name}`;
   const resolvedVirtualModuleId = `\0${virtualModuleId}`;
@@ -16,7 +17,7 @@ export function viteStorybookRendererFallbackPlugin(integrations: Integration[])
 
     load(id: string) {
       if (id === resolvedVirtualModuleId) {
-        return integrations
+        return safeIntegrations
           .filter((integration) => integration.storybookEntryPreview)
           .map(
             (integration) =>

--- a/packages/@storybook-astro/framework/tsup.config.ts
+++ b/packages/@storybook-astro/framework/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     'src/preset.ts',
     'src/testing.ts',
     'src/integrations/index.ts',
+    'src/middleware.ts',
   ],
   format: ['esm'],
   dts: false,
@@ -30,5 +31,6 @@ export default defineConfig({
     '@storybook/preact',
     '@storybook-astro/renderer',
     'storybook-solidjs',
+    'virtual:astro-container-renderers',
   ],
 });

--- a/packages/@storybook-astro/renderer/package.json
+++ b/packages/@storybook-astro/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook-astro/renderer",
-  "version": "0.1.0-beta.7",
+"version": "0.1.0-beta.10",
   "description": "Client-side renderer for Storybook Astro framework",
   "module": "./src/preset.ts",
   "type": "module",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,16 +2302,9 @@ __metadata:
     "@vitejs/plugin-react": "npm:^5.0.0"
     alpinejs: "npm:^3.14.9"
     astro: "npm:^5.6.1 || ^6.0.0-beta.0"
-    preact: "npm:*"
-    react: "npm:*"
-    react-dom: "npm:*"
-    solid-js: "npm:*"
-    storybook: "npm:*"
     storybook-solidjs: "npm:^1.0.0-beta.7"
-    svelte: "npm:*"
     vite: "npm:^6.2.5 || ^7.0.0"
     vite-plugin-solid: "npm:^2.11.10"
-    vue: "npm:*"
   peerDependencies:
     "@astrojs/alpinejs": ^0.4.5 || ^0.5.0-beta.0
     "@astrojs/preact": ^4.0.8 || ^5.0.0-beta.0
@@ -7742,7 +7735,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"preact@npm:*, preact@npm:^10.28.1":
+"preact@npm:^10.28.1":
   version: 10.28.1
   resolution: "preact@npm:10.28.1"
   checksum: 10c0/864aa7550f0a4b9f4f944a1e59f46f788b987d24bf5a532afefdb41e437c15fe80e933b7e8561980b8abe16565e39a224ec4b743382792bee0e1854d12e5771c
@@ -7903,7 +7896,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:*, react-dom@npm:^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0, react-dom@npm:^19.2.3":
+"react-dom@npm:^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0, react-dom@npm:^19.2.3":
   version: 19.2.3
   resolution: "react-dom@npm:19.2.3"
   dependencies:
@@ -7935,7 +7928,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:*, react@npm:^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0, react@npm:^19.2.3":
+"react@npm:^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0, react@npm:^19.2.3":
   version: 19.2.3
   resolution: "react@npm:19.2.3"
   checksum: 10c0/094220b3ba3a76c1b668f972ace1dd15509b157aead1b40391d1c8e657e720c201d9719537375eff08f5e0514748c0319063392a6f000e31303aafc4471f1436
@@ -8775,7 +8768,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"solid-js@npm:*, solid-js@npm:^1.9.10":
+"solid-js@npm:^1.9.10":
   version: 1.9.10
   resolution: "solid-js@npm:1.9.10"
   dependencies:
@@ -8920,7 +8913,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"storybook@npm:*, storybook@npm:10.2.7":
+"storybook@npm:10.2.7":
   version: 10.2.7
   resolution: "storybook@npm:10.2.7"
   dependencies:
@@ -9124,7 +9117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svelte@npm:*, svelte@npm:^5.46.0":
+"svelte@npm:^5.46.0":
   version: 5.46.0
   resolution: "svelte@npm:5.46.0"
   dependencies:
@@ -10112,7 +10105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue@npm:*, vue@npm:^3.5.26":
+"vue@npm:^3.5.26":
   version: 3.5.26
   resolution: "vue@npm:3.5.26"
   dependencies:


### PR DESCRIPTION
…try point, stale build docs

- Add ?? [] guards for integrations in all files that receive them
- Add middleware.ts as tsup entry point (with virtual module external)
- Add stale build warning to AGENTS.md and VERSIONING.md
- Bump both packages to 0.1.0-beta.10